### PR TITLE
Middleware周りの改善

### DIFF
--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -20,7 +20,6 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
-        CleanArchitectureMiddleware::class,
     ];
 
     /**
@@ -37,6 +36,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            CleanArchitectureMiddleware::class,
         ],
 
         'api' => [

--- a/src/app/Http/Middleware/CleanArchitectureMiddleware.php
+++ b/src/app/Http/Middleware/CleanArchitectureMiddleware.php
@@ -3,10 +3,37 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Routing\Router;
 
 class CleanArchitectureMiddleware
 {
-    public static $view;
+    /**
+     * @var mixed
+     */
+    private $data;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * CleanArchitectureMiddleware constructor.
+     * @param Router $router
+     */
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @param mixed $data
+     * @see \Illuminate\Routing\Router::toResponse()
+     */
+    public function setData($data): void
+    {
+        $this->data = $data;
+    }
 
     /**
      * Handle an incoming request.
@@ -18,6 +45,10 @@ class CleanArchitectureMiddleware
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        return $response;
+        if ($this->data === null) {
+            return $response;
+        }
+
+        return $this->router->prepareResponse($this->router->getCurrentRequest(), $this->data);
     }
 }

--- a/src/app/Http/Presenters/User/UserCreatePresenter.php
+++ b/src/app/Http/Presenters/User/UserCreatePresenter.php
@@ -11,9 +11,23 @@ use packages\UseCase\User\Create\UserCreateResponse;
 
 class UserCreatePresenter implements UserCreatePresenterInterface
 {
+    /**
+     * @var CleanArchitectureMiddleware
+     */
+    private $middleware;
+
+    /**
+     * UserCreatePresenter constructor.
+     * @param CleanArchitectureMiddleware $middleware
+     */
+    public function __construct(CleanArchitectureMiddleware $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
     public function output(UserCreateResponse $outputData)
     {
         $viewModel = new UserCreateViewModel($outputData->getCreatedUserId(), $outputData->getUserName());
-        CleanArchitectureMiddleware::$view = view('user.create', compact('viewModel'));
+        $this->middleware->setData(view('user.create', compact('viewModel')));
     }
 }

--- a/src/app/Http/Presenters/User/UserGetListPresenter.php
+++ b/src/app/Http/Presenters/User/UserGetListPresenter.php
@@ -13,6 +13,20 @@ use packages\UseCase\User\GetList\UserGetListResponse;
 class UserGetListPresenter implements UserGetListPresenterInterface
 {
     /**
+     * @var CleanArchitectureMiddleware
+     */
+    private $middleware;
+
+    /**
+     * UserGetListPresenter constructor.
+     * @param CleanArchitectureMiddleware $middleware
+     */
+    public function __construct(CleanArchitectureMiddleware $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
      * @param UserGetListResponse $outputData
      * @return mixed
      */
@@ -25,6 +39,7 @@ class UserGetListPresenter implements UserGetListPresenterInterface
             $outputData->users
         );
         $viewModel = new UserIndexViewModel($users);
-        CleanArchitectureMiddleware::$view = view('user.index', compact('viewModel'));
+
+        $this->middleware->setData(view('user.index', compact('viewModel')));
     }
 }

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Http\Middleware\CleanArchitectureMiddleware;
 use App\Http\Presenters\User\UserCreatePresenter;
 use App\Http\Presenters\User\UserGetListPresenter;
 use Illuminate\Support\ServiceProvider;
@@ -22,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
 
         // Mock で実行したい場合はコメント外す
 //        $this->registerForMock();
+
+        $this->app->singleton(CleanArchitectureMiddleware::class);
     }
 
     /**

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -50,15 +50,10 @@ $app = require_once __DIR__.'/../bootstrap/app.php';
 */
 
 $kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
-
-$kernelResponse = $kernel->handle(
+$response = $kernel->handle(
     $request = Illuminate\Http\Request::capture()
 );
 
-$view = \App\Http\Middleware\CleanArchitectureMiddleware::$view;
-$response = $view !== null
-    ? new \Symfony\Component\HttpFoundation\Response($view)
-    : $kernelResponse;
 $response->send();
 
 $kernel->terminate($request, $response);


### PR DESCRIPTION
Qiitaの記事を拝見して少しHTTP Middleware周りの処理が気になったのでPRを出させていただきます。

### 修正内容
- ViewオブジェクトからHTTP Responseオブジェクトへの変換処理をCleanArchitectureMiddlewareに移し、エントリポイント(public/index.php)のコードをLaravelのデフォルトに戻した
- View以外のデータをMiddlewareに渡せるように
- CleanArchitectureMiddlewareを一番内側（Controllerの一つ外側）に移動
- CleanArchitectureMiddlewareをシングルトン化

### 改善点
- 他のHTTP Middlewareの動作に影響が出ない
元のコードだと$kernelResponseを捨てているため、AddQueuedCookiesToResponseなど、Controllerから得られたHTTP Responseオブジェクトにヘッダなどを後付けするタイプのMiddlewareが正常に動作しないと思われます。

- Laravelのプレゼンテーション機能を活用可能に
view()ヘルパーによるビューテンプレートのレンダリング以外にも、テキストレスポンス、配列、JSONレスポンス、リダイレクトレスポンスなどのデータをMiddlewareに渡せるようになり、Laravelのプレゼンテーションレイヤ用の機能を活かせます。

例）
```
// ※ 各種PresenterにてMiddlewareをコンストラクタインジェクションする想定
// リダイレクト
$this->middleware->setData(redirect()->to("user/{$outputData->getCreatedUserId()}"));

// 配列からJSONレスポンス
$this->middleware->setData(['id' => $outputData->getCreatedUserId(), 'name' => $outputData->getUserName()]);
```

